### PR TITLE
Reduce dependency tree by downloading flow binary manually.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 'use strict';
-var bin = require('./lib');
-module.exports = bin.path();
+
+module.exports = require('./lib').path;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,13 +8,88 @@
  */
 'use strict';
 var path = require('path');
-var BinWrapper = require('bin-wrapper');
+var fs = require('fs');
+var os = require('os');
+var spawnSync = require('spawn-sync');
+var https = require('follow-redirects').https;
+var unzip = require('unzip2');
 
 var VERSION = '0.25.0';
 var BASE = 'https://github.com/facebook/flow/releases/download/v' + VERSION + '/';
+var DEST = path.join(__dirname, '..', 'vendor');
+var downloadPaths = {
+	linux: BASE + 'flow-linux64-v' + VERSION + '.zip',
+	darwin: BASE + 'flow-osx-v' + VERSION + '.zip'
+};
 
-module.exports = new BinWrapper()
-	.src(BASE + 'flow-osx-v' + VERSION + '.zip', 'darwin')
-	.src(BASE + 'flow-linux64-v' + VERSION + '.zip', 'linux', 'x64')
-	.dest(path.join(__dirname, '../vendor'))
-	.use('flow');
+// Exports
+var bin = module.exports.path = path.join(DEST, 'flow');
+var runSync = module.exports.runSync = function (args) {
+	return spawnSync(bin, args, {stdio: 'pipe'});
+};
+module.exports.run = function (args, cb) {
+	var cp = runSync(args);
+	if (cp.error) {
+		return cb(cp.error);
+	} else if (cp.status !== 0) {
+		return cb(new Error('Nonzero status: ' + cp.status + ' (' + cp.stdout + ')'));
+	}
+	cb(null, cp);
+};
+module.exports.VERSION = VERSION;
+
+function install(cb) {
+	var osType = os.type().toLowerCase();
+	var downloadPath = downloadPaths[osType];
+	if (!downloadPath || (osType === 'linux' && os.arch() !== 'x64')) {
+		throw new Error('Unsupported OS: ' + osType + '. Supported OSs are ' + Object.keys(downloadPaths) + '.');
+	}
+
+	try {
+		fs.mkdirSync(DEST);
+	} catch (e) {
+		if (e.code !== 'EEXIST') {
+			return cb(e);
+		}
+	}
+	var request = https.get(downloadPath, function (response) {
+		response
+		.pipe(unzip.Parse()) // eslint-disable-line new-cap
+		.on('entry', function (entry) {
+			if (entry.type === 'File') {
+				entry.pipe(fs.createWriteStream(path.join(DEST, path.basename(entry.path))));
+			}
+		})
+		.on('close', function () {
+			// Chmod so it's runnable.
+			fs.chmodSync(path.join(DEST, 'flow'), 755);
+			cb();
+		});
+	});
+
+	request.on('error', function (err) {
+		var installErr = new Error('Error receiving flow from ' + downloadPath + ': ' + err);
+		cb(installErr);
+	});
+}
+
+// Returns true iff flow is installed and the correct version.
+function isInstalled() {
+	var exists = fs.existsSync(path.join(DEST, 'flow'));
+	return exists && doesVersionMatch();
+}
+
+function doesVersionMatch() {
+	var cp = runSync(['version']);
+	return cp.stdout.toString().trim().slice(-VERSION.length) === VERSION;
+}
+
+module.exports.install = function maybeInstall(cb) {
+	if (isInstalled()) {
+		console.log('✔ Flow already installed, skipping download.');
+		cb();
+	} else {
+		console.log('ℹ Installing Flow binary...');
+		install(cb);
+	}
+};

--- a/lib/install.js
+++ b/lib/install.js
@@ -7,15 +7,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 'use strict';
-var log = require('logalot');
 var bin = require('./');
 
 bin.run(['--version'], function (err) {
 	if (err) {
-		log.error(err.message);
-		log.error('flow binary test failed');
+		console.error(err.message);
+		console.error('✖ Flow binary test failed!');
 		return;
 	}
 
-	log.success('flow binary test passed successfully');
+	console.log('✔ Flow binary test passed successfully.');
 });

--- a/package.json
+++ b/package.json
@@ -40,12 +40,13 @@
     "wrapper"
   ],
   "dependencies": {
-    "bin-wrapper": "^3.0.2",
-    "logalot": "^2.0.0"
+    "follow-redirects": "^0.1.0",
+    "spawn-sync": "^1.0.15",
+    "unzip2": "^0.2.5"
   },
   "devDependencies": {
     "ava": "*",
-    "bin-check": "^3.0.0",
+    "rimraf": "^2.5.2",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,10 +6,24 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+import path from 'path';
 import test from 'ava';
-import binCheck from 'bin-check';
-import flow from './';
+import rimraf from 'rimraf';
+import flow from './lib';
 
-test('returns path to binary and verify that it is working', async t => {
-	t.true(await binCheck(flow, ['--version']));
+test.serial.cb('installs', t => {
+	rimraf.sync(path.join(__dirname, 'vendor'));
+	t.plan(1);
+	flow.install(err => {
+		t.true(!err);
+		t.end();
+	});
+});
+
+test('returns path to binary and verify that it is working', t => {
+	const cp = flow.runSync(['version']);
+	t.true(cp.error === undefined);
+	t.true(cp.status === 0);
+	const output = cp.stdout.toString().trim();
+	t.true(output.slice(-flow.VERSION.length) === flow.VERSION);
 });


### PR DESCRIPTION
Maybe this is a no-go because the code *is* more complex, but this significantly speeds up a fresh install.

The dependency tree goes from:

```
├─┬ flow-bin@0.25.0
│ ├─┬ bin-wrapper@3.0.2
│ │ ├─┬ bin-check@2.0.0
│ │ │ └── executable@1.1.0
│ │ ├─┬ download@4.4.3
│ │ │ ├─┬ caw@1.2.0
│ │ │ │ ├─┬ get-proxy@1.1.0
│ │ │ │ │ └─┬ rc@1.1.6
│ │ │ │ │   ├── deep-extend@0.4.1
│ │ │ │ │   ├── ini@1.3.4
│ │ │ │ │   └── strip-json-comments@1.0.4
│ │ │ │ ├── is-obj@1.0.1
│ │ │ │ └── object-assign@3.0.0
│ │ │ ├─┬ concat-stream@1.5.1
│ │ │ │ └── typedarray@0.0.6
│ │ │ ├─┬ filenamify@1.2.1
│ │ │ │ ├── filename-reserved-regex@1.0.0
│ │ │ │ ├── strip-outer@1.0.0
│ │ │ │ └── trim-repeated@1.0.0
│ │ │ ├─┬ got@5.6.0
│ │ │ │ ├─┬ create-error-class@3.0.2
│ │ │ │ │ └── capture-stack-trace@1.0.0
│ │ │ │ ├── duplexer2@0.1.4
│ │ │ │ ├── is-plain-obj@1.1.0
│ │ │ │ ├── is-redirect@1.0.0
│ │ │ │ ├── is-retry-allowed@1.0.0
│ │ │ │ ├── is-stream@1.0.1
│ │ │ │ ├── lowercase-keys@1.0.0
│ │ │ │ ├── node-status-codes@1.0.0
│ │ │ │ ├─┬ parse-json@2.2.0
│ │ │ │ │ └─┬ error-ex@1.3.0
│ │ │ │ │   └── is-arrayish@0.2.1
│ │ │ │ ├── timed-out@2.0.0
│ │ │ │ ├── unzip-response@1.0.0
│ │ │ │ └─┬ url-parse-lax@1.0.0
│ │ │ │   └── prepend-http@1.0.4
│ │ │ ├─┬ gulp-decompress@1.2.0
│ │ │ │ ├─┬ archive-type@3.2.0
│ │ │ │ │ └── file-type@3.8.0
│ │ │ │ ├─┬ decompress@3.0.0
│ │ │ │ │ ├─┬ buffer-to-vinyl@1.1.0
│ │ │ │ │ │ └── uuid@2.0.2
│ │ │ │ │ ├─┬ decompress-tar@3.1.0
│ │ │ │ │ │ ├── is-tar@1.0.0
│ │ │ │ │ │ ├── object-assign@2.1.1
│ │ │ │ │ │ ├─┬ strip-dirs@1.1.1
│ │ │ │ │ │ │ ├─┬ is-absolute@0.1.7
│ │ │ │ │ │ │ │ └── is-relative@0.1.3
│ │ │ │ │ │ │ ├── is-natural-number@2.1.1
│ │ │ │ │ │ │ └── sum-up@1.0.3
│ │ │ │ │ │ ├─┬ tar-stream@1.5.2
│ │ │ │ │ │ │ └── end-of-stream@1.1.0
│ │ │ │ │ │ └─┬ vinyl@0.4.6
│ │ │ │ │ │   └── clone@0.2.0
│ │ │ │ │ ├─┬ decompress-tarbz2@3.1.0
│ │ │ │ │ │ ├── is-bzip2@1.0.0
│ │ │ │ │ │ ├── object-assign@2.1.1
│ │ │ │ │ │ ├─┬ seek-bzip@1.0.5
│ │ │ │ │ │ │ └── commander@2.8.1
│ │ │ │ │ │ └─┬ vinyl@0.4.6
│ │ │ │ │ │   └── clone@0.2.0
│ │ │ │ │ ├─┬ decompress-targz@3.1.0
│ │ │ │ │ │ ├── is-gzip@1.0.0
│ │ │ │ │ │ ├── object-assign@2.1.1
│ │ │ │ │ │ └─┬ vinyl@0.4.6
│ │ │ │ │ │   └── clone@0.2.0
│ │ │ │ │ ├─┬ decompress-unzip@3.4.0
│ │ │ │ │ │ ├── is-zip@1.0.0
│ │ │ │ │ │ ├── stat-mode@0.2.1
│ │ │ │ │ │ ├── through2@2.0.1
│ │ │ │ │ │ └─┬ yauzl@2.4.2
│ │ │ │ │ │   └─┬ fd-slicer@1.0.1
│ │ │ │ │ │     └── pend@1.2.0
│ │ │ │ │ └── vinyl-assign@1.2.1
│ │ │ │ └─┬ gulp-util@3.0.7
│ │ │ │   ├── array-differ@1.0.0
│ │ │ │   ├── beeper@1.1.0
│ │ │ │   ├── dateformat@1.0.12
│ │ │ │   ├─┬ fancy-log@1.2.0
│ │ │ │   │ └── time-stamp@1.0.1
│ │ │ │   ├─┬ gulplog@1.0.0
│ │ │ │   │ └── glogg@1.0.0
│ │ │ │   ├─┬ has-gulplog@0.1.0
│ │ │ │   │ └── sparkles@1.0.0
│ │ │ │   ├── lodash._reescape@3.0.0
│ │ │ │   ├── lodash._reevaluate@3.0.0
│ │ │ │   ├── lodash._reinterpolate@3.0.0
│ │ │ │   ├─┬ lodash.template@3.6.2
│ │ │ │   │ ├── lodash._basecopy@3.0.1
│ │ │ │   │ ├── lodash._basetostring@3.0.1
│ │ │ │   │ ├── lodash._basevalues@3.0.0
│ │ │ │   │ ├── lodash._isiterateecall@3.0.9
│ │ │ │   │ ├── lodash.escape@3.2.0
│ │ │ │   │ ├─┬ lodash.keys@3.1.2
│ │ │ │   │ │ ├── lodash._getnative@3.9.1
│ │ │ │   │ │ ├── lodash.isarguments@3.0.8
│ │ │ │   │ │ └── lodash.isarray@3.0.4
│ │ │ │   │ ├── lodash.restparam@3.6.1
│ │ │ │   │ └── lodash.templatesettings@3.1.1
│ │ │ │   ├─┬ multipipe@0.1.2
│ │ │ │   │ └─┬ duplexer2@0.0.2
│ │ │ │   │   └── readable-stream@1.1.14
│ │ │ │   ├── object-assign@3.0.0
│ │ │ │   ├── through2@2.0.1
│ │ │ │   └── vinyl@0.5.3
│ │ │ ├── gulp-rename@1.2.2
│ │ │ ├── is-url@1.2.1
│ │ │ ├── read-all-stream@3.1.0
│ │ │ ├── stream-combiner2@1.1.1
│ │ │ ├─┬ vinyl@1.1.1
│ │ │ │ ├── clone@1.0.2
│ │ │ │ ├── clone-stats@0.0.1
│ │ │ │ └── replace-ext@0.0.1
│ │ │ ├─┬ vinyl-fs@2.4.3
│ │ │ │ ├─┬ duplexify@3.4.3
│ │ │ │ │ └── end-of-stream@1.0.0
│ │ │ │ ├─┬ glob-stream@5.3.2
│ │ │ │ │ ├── ordered-read-streams@0.3.0
│ │ │ │ │ ├─┬ through2@0.6.5
│ │ │ │ │ │ └─┬ readable-stream@1.0.34
│ │ │ │ │ │   └── isarray@0.0.1
│ │ │ │ │ ├─┬ to-absolute-glob@0.1.1
│ │ │ │ │ │ └── extend-shallow@2.0.1
│ │ │ │ │ └─┬ unique-stream@2.2.1
│ │ │ │ │   └─┬ json-stable-stringify@1.0.1
│ │ │ │ │     └── jsonify@0.0.0
│ │ │ │ ├─┬ gulp-sourcemaps@1.6.0
│ │ │ │ │ └── through2@2.0.1
│ │ │ │ ├── is-valid-glob@0.3.0
│ │ │ │ ├── lazystream@1.0.0
│ │ │ │ ├─┬ lodash.isequal@4.2.0
│ │ │ │ │ ├── lodash._root@3.0.1
│ │ │ │ │ └── lodash.keys@4.0.7
│ │ │ │ ├── merge-stream@1.0.0
│ │ │ │ ├─┬ strip-bom@2.0.0
│ │ │ │ │ └── is-utf8@0.2.1
│ │ │ │ ├─┬ strip-bom-stream@1.0.0
│ │ │ │ │ └── first-chunk-stream@1.0.0
│ │ │ │ ├── through2@2.0.1
│ │ │ │ ├─┬ through2-filter@2.0.0
│ │ │ │ │ └── through2@2.0.1
│ │ │ │ └── vali-date@1.0.0
│ │ │ └─┬ ware@1.3.0
│ │ │   └─┬ wrap-fn@0.1.5
│ │ │     └── co@3.1.0
│ │ ├─┬ each-async@1.1.1
│ │ │ ├── onetime@1.1.0
│ │ │ └── set-immediate-shim@1.0.1
│ │ ├── lazy-req@1.1.0
│ │ └── os-filter-obj@1.0.3
│ └─┬ logalot@2.1.0
│   ├─┬ figures@1.7.0
│   │ └── object-assign@4.1.0
│   └─┬ squeak@1.3.0
│     ├── console-stream@0.1.1
│     └─┬ lpad-align@1.1.0
│       ├── longest@1.0.1
│       └── lpad@2.0.1
```

To:

```
flow-bin@0.25.0
├─┬ follow-redirects@0.1.0
│ ├─┬ debug@2.2.0
│ │ └── ms@0.7.1
│ └── stream-consume@0.1.0
├─┬ spawn-sync@1.0.15
│ ├─┬ concat-stream@1.5.1
│ │ ├── inherits@2.0.1
│ │ ├─┬ readable-stream@2.0.6
│ │ │ ├── isarray@1.0.0
│ │ │ ├── process-nextick-args@1.0.7
│ │ │ └── util-deprecate@1.0.2
│ │ └── typedarray@0.0.6
│ └── os-shim@0.1.3
└─┬ unzip2@0.2.5
  ├─┬ binary@0.3.0
  │ ├── buffers@0.1.1
  │ └─┬ chainsaw@0.1.0
  │   └── traverse@0.3.9
  ├─┬ fstream@0.1.31
  │ ├── graceful-fs@3.0.8
  │ ├─┬ mkdirp@0.5.1
  │ │ └── minimist@0.0.8
  │ └─┬ rimraf@2.5.2
  │   └─┬ glob@7.0.3
  │     ├─┬ inflight@1.0.4
  │     │ └── wrappy@1.0.2
  │     ├─┬ minimatch@3.0.0
  │     │ └─┬ brace-expansion@1.1.4
  │     │   ├── balanced-match@0.4.1
  │     │   └── concat-map@0.0.1
  │     ├── once@1.3.3
  │     └── path-is-absolute@1.0.0
  ├── match-stream@0.0.2
  ├─┬ pullstream@0.4.1
  │ ├── over@0.0.5
  │ └── slice-stream@1.0.0
  ├─┬ readable-stream@1.0.34
  │ ├── core-util-is@1.0.2
  │ ├── isarray@0.0.1
  │ └── string_decoder@0.10.31
  └── setimmediate@1.0.4
```

It otherwise maintains compatibility, with the advantage that `run()` now calls back with `(err, childProcess)` arity, and we have a new `runSync()`.