### PR TITLE
Update repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.30.0",
   "description": "Binary wrapper for Flow - A static type checker for JavaScript",
   "license": "MIT",
-  "repository": "sindresorhus/flow-bin",
+  "repository": "flowtype/flow-bin",
   "author": {
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",


### PR DESCRIPTION
This is used on https://www.npmjs.com/package/flow-bin and while the old repo still redirects it seems nice to point to the main repo directly.