### PR TITLE
chore: remove outdated version of node from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '0.12'
-    - nodejs_version: '0.10'
+    - nodejs_version: 14
+    - nodejs_version: 12
+    - nodejs_version: 10
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: 6
-    - nodejs_version: 5
-    - nodejs_version: 4
     - nodejs_version: '0.12'
     - nodejs_version: '0.10'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - npm install -g npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install --loglevel=warn
-  - choco install mongodb
+  - choco install make
   - make test
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ install:
   - npm install -g npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install --loglevel=warn
+  - choco install mongodb
   - make test
 
 test_script:


### PR DESCRIPTION
removed older version of node from appveyor config that is causing the ci to fail